### PR TITLE
Python 2.6 support for HTTPS connection library

### DIFF
--- a/iyzipay/iyzipay_resource.py
+++ b/iyzipay/iyzipay_resource.py
@@ -2,7 +2,6 @@ import random
 import string
 import base64
 import hashlib
-import http.client
 import json
 import sys
 import iyzipay
@@ -15,7 +14,12 @@ class IyzipayResource:
     RANDOM_STRING_SIZE = 8
 
     def connect(self, method, url, options, request=None, pki=None):
-        connection = http.client.HTTPSConnection(options['base_url'])
+        if (2,6) <= sys.version_info < (3,0):
+            import httplib
+            connection = httplib.HTTPSConnection(options['base_url'])
+        else:
+            import http.client
+            connection = http.client.HTTPSConnection(options['base_url'])
         request_json = json.dumps(request)
         connection.request(method, url, request_json, self.get_http_header(options, pki))
         return connection.getresponse()


### PR DESCRIPTION
Native Python 2.6 support for HTTPS connection library (without __future__)