### PR TITLE
Start adding unit tests

### DIFF
--- a/requirements.testing.txt
+++ b/requirements.testing.txt
@@ -1,0 +1,3 @@
+pytest
+pytest-cov
+pytest-runner

--- a/tests/test_pki_builder.py
+++ b/tests/test_pki_builder.py
@@ -32,3 +32,19 @@ class PKIBuilderTest(unittest.TestCase):
         pki_builder = iyzipay.PKIBuilder('')
         pki_builder.append_price('price', '')
         self.assertEqual(pki_builder.get_request_string(), '[]')
+
+    def test_append_array_when_value_available(self):
+        enabledInstallments = ['2', '3', '6', '9']
+        pki_builder = iyzipay.PKIBuilder('')
+        pki_builder.append_array('data', enabledInstallments)
+        self.assertEqual(pki_builder.get_request_string(), '[data=[2, 3, 6, 9]]')
+
+    def test_append_array_when_value_not_available(self):
+        pki_builder = iyzipay.PKIBuilder('')
+        pki_builder.append_array('data')
+        self.assertEqual(pki_builder.get_request_string(), '[]')
+
+    def test_append_array_when_value_empty(self):
+        pki_builder = iyzipay.PKIBuilder('')
+        pki_builder.append_array('data', [])
+        self.assertEqual(pki_builder.get_request_string(), '[]')

--- a/tests/test_pki_builder.py
+++ b/tests/test_pki_builder.py
@@ -1,0 +1,19 @@
+import unittest
+import iyzipay
+
+class PKIBuilderTest(unittest.TestCase):
+
+    def test_append_when_value_available(self):
+        pki_builder = iyzipay.PKIBuilder('')
+        pki_builder.append('key', 'value')
+        self.assertEqual(pki_builder.get_request_string(), '[key=value]')
+
+    def test_append_when_value_not_available(self):
+        pki_builder = iyzipay.PKIBuilder('')
+        pki_builder.append('key')
+        self.assertEqual(pki_builder.get_request_string(), '[]')
+
+    def test_append_when_value_empty(self):
+        pki_builder = iyzipay.PKIBuilder('')
+        pki_builder.append('key', '')
+        self.assertEqual(pki_builder.get_request_string(), '[]')

--- a/tests/test_pki_builder.py
+++ b/tests/test_pki_builder.py
@@ -17,3 +17,18 @@ class PKIBuilderTest(unittest.TestCase):
         pki_builder = iyzipay.PKIBuilder('')
         pki_builder.append('key', '')
         self.assertEqual(pki_builder.get_request_string(), '[]')
+
+    def test_append_price_when_value_available(self):
+        pki_builder = iyzipay.PKIBuilder('')
+        pki_builder.append_price('price', 100)
+        self.assertEqual(pki_builder.get_request_string(), '[price=100.0]')
+
+    def test_append_price_when_value_not_available(self):
+        pki_builder = iyzipay.PKIBuilder('')
+        pki_builder.append_price('price')
+        self.assertEqual(pki_builder.get_request_string(), '[]')
+
+    def test_append_price_when_value_empty(self):
+        pki_builder = iyzipay.PKIBuilder('')
+        pki_builder.append_price('price', '')
+        self.assertEqual(pki_builder.get_request_string(), '[]')


### PR DESCRIPTION
- With this commit there is a new folder named `tests` which is created to contain test classes. For now there is only one, which is for `PKIBuilder`. Coverage for `PKIBuilder` is now 100%. It's the first shape of the fix for #33.
- To install the dependencies for unit tests just run `pip install -r requirements.testing.txt`
- For running the tests you can use `py.test -s -v` command.