### PR TITLE
[URGENT] generate_v2_hash bug fix

### DIFF
--- a/iyzipay/iyzipay_resource.py
+++ b/iyzipay/iyzipay_resource.py
@@ -76,7 +76,7 @@ class IyzipayResource:
             'randomKey:' + random_str,
             'signature:' + signature
         ]
-        return base64.b64encode('&'.join(authorization_params).encode())
+        return base64.b64encode('&'.join(authorization_params).encode()).decode()
 
     def get_plain_http_header(self, options):
         return self.get_http_header_v1(None, options)


### PR DESCRIPTION
Python 2.7'de base64.b64encode fonksiyonu string olarak dönüyor ama Python 3 ile byte dönmekte. get_http_header_v2 fonksiyonu Authorization kısmını oluştururken b'HASH' olarak eklemekteydi. Bundan dolayı doğru authentication yapılamamakta.