### PR TITLE
Add wheel to setup_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     name='iyzipay',
     version='1.0.38',
     use_scm_version=True,
-    setup_requires=['setuptools_scm', 'future'],
+    setup_requires=['setuptools_scm', 'future', 'wheel'],
     description='iyzipay api python client',
     long_description=README,
     author='iyzico',


### PR DESCRIPTION
Hey, apparently wheel is needed for the setup of this package. Tried to install it on a fresh ubuntu without wheel installed on my venv and needed to install wheel manually. Not much of a problem when you know what causes it, but it may take some time for beginners to understand what's wrong. Adding wheel to setup_requires here should fix the issue. 